### PR TITLE
Revised Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 group 'com.hosopy'
 version '0.2.0'
 
-apply plugin: 'java'
+//apply plugin: 'java'
+apply plugin: 'java-library'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     // Java 7+. These platforms lack support for TLS 1.2 and should not be used. But because
     // upgrading is difficult we will backport critical fixes to the 3.12.x branch
     // through December 31, 2020.
-    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
-    implementation 'com.google.code.gson:gson:2.3.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.google.code.gson:gson:2.8.9'
 
     testImplementation 'junit:junit:4.11'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 group 'com.hosopy'
 version '0.2.0'
 
-//apply plugin: 'java'
-apply plugin: 'java-library'
+apply plugin: 'java'
 
 repositories {
     mavenCentral()
-    jcenter()
+//    jcenter()
     google()
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - oraclejdk7
+  - openjdk17

--- a/src/main/java/com/hosopy/actioncable/Channel.java
+++ b/src/main/java/com/hosopy/actioncable/Channel.java
@@ -24,6 +24,7 @@ public class Channel {
     private final JsonObject params = new JsonObject();
 
     private String identifier;
+    private String name;
 
     /**
      * Constructor
@@ -31,6 +32,7 @@ public class Channel {
      * @param channel Channel name
      */
     public Channel(String channel) {
+        this.name = channel;
         params.addProperty(KEY_CHANNEL, channel);
     }
 
@@ -91,5 +93,9 @@ public class Channel {
             params.add(key, value);
             identifier = null;
         }
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/src/main/java/com/hosopy/actioncable/Channel.java
+++ b/src/main/java/com/hosopy/actioncable/Channel.java
@@ -76,6 +76,7 @@ public class Channel {
         addParamInternal(key, value);
     }
 
+
     public String toIdentifier() {
         synchronized (params) {
             if (identifier == null) {

--- a/src/main/java/com/hosopy/actioncable/Channel.java
+++ b/src/main/java/com/hosopy/actioncable/Channel.java
@@ -76,7 +76,7 @@ public class Channel {
         addParamInternal(key, value);
     }
 
-    /*package*/ String toIdentifier() {
+    public String toIdentifier() {
         synchronized (params) {
             if (identifier == null) {
                 identifier = GSON.toJson(params);

--- a/src/main/java/com/hosopy/actioncable/Command.java
+++ b/src/main/java/com/hosopy/actioncable/Command.java
@@ -3,7 +3,7 @@ package com.hosopy.actioncable;
 import com.google.gson.*;
 import com.google.gson.annotations.Expose;
 
-class Command {
+public class Command {
 
     private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
@@ -23,7 +23,7 @@ class Command {
         this(command, identifier, null);
     }
 
-    private Command(String command, String identifier, String data) {
+    public Command(String command, String identifier, String data) {
         this.command = command;
         this.identifier = identifier;
         this.data = data;
@@ -37,7 +37,7 @@ class Command {
         return new Command("unsubscribe", identifier);
     }
 
-    static Command message(String identifier, JsonObject params) {
+    public static Command message(String identifier, JsonObject params) {
         return new Command("message", identifier, params.toString());
     }
 

--- a/src/main/java/com/hosopy/actioncable/Command.java
+++ b/src/main/java/com/hosopy/actioncable/Command.java
@@ -41,6 +41,10 @@ class Command {
         return new Command("message", identifier, params.toString());
     }
 
+    static Command pong() {
+        return new Command("pong", null);
+    }
+
     /*package*/ String toJson() {
         return GSON.toJson(this);
     }

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -291,10 +291,13 @@ public class Connection {
 
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+            Connection.this.state = State.CLOSED;
+
             EventLoop.execute(new Runnable() {
                 @Override
                 public void run() {
                     state = State.CLOSED;
+                    Connection.this.webSocket = null;
 
                     if (listener != null) {
                         listener.onFailure(new WebSocketException(t));
@@ -323,6 +326,12 @@ public class Connection {
                 @Override
                 public void run() {
                     state = State.CLOSING;
+                    try{
+                        webSocket.close(code, reason);
+                        Connection.this.webSocket = null;
+                    } catch (IllegalStateException e) {
+                        //do nothing
+                    }
 
                     if (listener != null) {
                         listener.onClosing();

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -136,6 +136,8 @@ public class Connection {
             public void run() {
                 if (isOpen()) {
                     fireOnFailure(new IllegalStateException("Must close existing connection before opening"));
+                } else if (isConnecting()) {
+                    fireOnFailure(new IllegalStateException("Already connection, must close existing connection before opening"));
                 } else {
                     doOpen();
                 }

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -1,5 +1,6 @@
 package com.hosopy.actioncable;
 
+import com.hosopy.actioncable.annotation.WebSocketException;
 import com.hosopy.concurrent.EventLoop;
 import com.hosopy.util.QueryStringUtils;
 
@@ -291,7 +292,7 @@ public class Connection {
                     state = State.CLOSED;
 
                     if (listener != null) {
-                        listener.onFailure((Exception) t);
+                        listener.onFailure(new WebSocketException(t));
                     }
                 }
             });

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -122,6 +122,8 @@ public class Connection {
 
     private boolean isReopening = false;
 
+    private GeneralListener generalListener;
+
     /*package*/ Connection(URI uri, Options options) {
         this.uri = uri;
         this.options = options;
@@ -241,7 +243,9 @@ public class Connection {
 
     private void doSend(String data) {
         if (webSocket != null) {
-            webSocket.send(data);
+            boolean isSent = webSocket.send(data);
+            if (isSent && generalListener != null)
+                generalListener.onSend(data);
         }
     }
 
@@ -260,6 +264,9 @@ public class Connection {
         }
     }
 
+    /*package*/ void setGeneralListener(GeneralListener listener) {
+        generalListener = listener;
+    }
     private WebSocketListener webSocketListener = new WebSocketListener() {
         @Override
         public void onOpen(WebSocket webSocket, Response response) {

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -180,6 +180,15 @@ public class Connection {
     /*package*/ boolean isOpen() {
         return webSocket != null && isState(State.OPEN);
     }
+    /*package*/ boolean isConnecting() {
+        return isState(State.CONNECTING);
+    }
+    /*package*/ boolean isClosed() {
+        return isState(State.CLOSED);
+    }
+    /*package*/ boolean isClosing() {
+        return isState(State.CLOSING);
+    }
 
     /*package*/ boolean send(final String data) {
         if (isOpen()) {

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -291,7 +291,7 @@ public class Connection {
 
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
-            if(webSocket != mWebSocket) return;
+            if (mWebSocket != null && webSocket != mWebSocket) return;
             Connection.this.state = State.CLOSED;
 
             EventLoop.execute(new Runnable() {

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -291,6 +291,7 @@ public class Connection {
 
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+            if(webSocket != mWebSocket) return;
             Connection.this.state = State.CLOSED;
 
             EventLoop.execute(new Runnable() {
@@ -320,6 +321,13 @@ public class Connection {
 
         @Override
         public void onClosing(WebSocket webSocket, int code, String reason) {
+            if (mWebSocket != null && webSocket != mWebSocket) {
+                try {
+                    webSocket.close(code, reason);
+                } catch (Exception e) {
+                }
+                return;
+            }
             Connection.this.state = State.CLOSING;
 
             EventLoop.execute(new Runnable() {
@@ -348,6 +356,7 @@ public class Connection {
 
         @Override
         public void onClosed(WebSocket webSocket, int code, String reason) {
+            if (mWebSocket != null && webSocket != mWebSocket) return;
             Connection.this.state = State.CLOSED;
 
             EventLoop.execute(new Runnable() {

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -30,7 +30,8 @@ public class Connection {
         CONNECTING,
         OPEN,
         CLOSING,
-        CLOSED
+        CLOSED,
+        IDEAL
     }
 
     /*package*/ interface Listener {
@@ -110,7 +111,7 @@ public class Connection {
         }
     }
 
-    private State state = State.CONNECTING;
+    private State state = State.IDEAL;
 
     private URI uri;
 

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -90,6 +90,13 @@ public class Connection {
          */
         public OkHttpClientFactory okHttpClientFactory;
 
+ /**
+         * Whether to pingPong is automatically.
+         * <p/>
+         * <p>If pingPong is true, the client attempts to response to the server ping by send 'pong' command.</p>
+         */
+        public boolean pingPong = false;
+        
         /**
          * The ping interval on how often a ping is sent over the websocket connection
          * <p/>

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -1,13 +1,9 @@
 package com.hosopy.actioncable;
 
-import com.hosopy.actioncable.annotation.WebSocketException;
 import com.hosopy.concurrent.EventLoop;
 import com.hosopy.util.QueryStringUtils;
 
-import java.io.IOException;
-import java.net.CookieHandler;
 import java.net.URI;
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -21,8 +17,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
-import okio.Buffer;
-import okio.ByteString;
 
 
 public class Connection {

--- a/src/main/java/com/hosopy/actioncable/Connection.java
+++ b/src/main/java/com/hosopy/actioncable/Connection.java
@@ -114,7 +114,7 @@ public class Connection {
 
     private Listener listener;
 
-    private WebSocket webSocket;
+    private WebSocket mWebSocket;
 
     private boolean isReopening = false;
 
@@ -149,11 +149,11 @@ public class Connection {
         EventLoop.execute(new Runnable() {
             @Override
             public void run() {
-                if (webSocket != null) {
+                if (mWebSocket != null) {
                     try {
                         // http://tools.ietf.org/html/rfc6455#section-7.4.1
                         if (!isState(State.CLOSING, State.CLOSED)) {
-                            webSocket.close(1000, "connection closed manually");
+                            mWebSocket.close(1000, "connection closed manually");
                             state = State.CLOSING;
                         }
                     } catch (IllegalStateException e) {
@@ -174,7 +174,7 @@ public class Connection {
     }
 
     /*package*/ boolean isOpen() {
-        return webSocket != null && isState(State.OPEN);
+        return mWebSocket != null && isState(State.OPEN);
     }
     /*package*/ boolean isConnecting() {
         return isState(State.CONNECTING);
@@ -249,8 +249,8 @@ public class Connection {
     }
 
     private void doSend(String data) {
-        if (webSocket != null) {
-            boolean isSent = webSocket.send(data);
+        if (mWebSocket != null) {
+            boolean isSent = mWebSocket.send(data);
             if (isSent && generalListener != null)
                 generalListener.onSend(data);
         }
@@ -278,7 +278,7 @@ public class Connection {
         @Override
         public void onOpen(WebSocket webSocket, Response response) {
             Connection.this.state = State.OPEN;
-            Connection.this.webSocket = webSocket;
+            Connection.this.mWebSocket = webSocket;
             EventLoop.execute(new Runnable() {
                 @Override
                 public void run() {
@@ -297,7 +297,7 @@ public class Connection {
                 @Override
                 public void run() {
                     state = State.CLOSED;
-                    Connection.this.webSocket = null;
+                    Connection.this.mWebSocket = null;
 
                     if (listener != null) {
                         listener.onFailure(new WebSocketException(t));
@@ -328,7 +328,7 @@ public class Connection {
                     state = State.CLOSING;
                     try{
                         webSocket.close(code, reason);
-                        Connection.this.webSocket = null;
+                        Connection.this.mWebSocket = null;
                     } catch (IllegalStateException e) {
                         //do nothing
                     }

--- a/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
+++ b/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
@@ -66,8 +66,9 @@ public class ConnectionMonitor {
 
     /*package*/ void start() {
         reset();
-        stoppedAt = 0;
+        pingedAt = 0;
         startedAt = now();
+        stoppedAt = 0;
         poll();
     }
 

--- a/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
+++ b/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
@@ -10,6 +10,8 @@ public class ConnectionMonitor {
 
     private static final int STALE_THRESHOLD = 6; // Server::Connections::BEAT_INTERVAL * 2 (missed two pings)
 
+    private int staleThresholdInSecond = STALE_THRESHOLD;
+
     private final Connection connection;
 
     private final ScheduledExecutorService pollExecutorService;
@@ -98,11 +100,11 @@ public class ConnectionMonitor {
     }
 
     private boolean connectionIsStale() {
-        return secondsSince(pingedAt > 0 ? pingedAt : startedAt) > STALE_THRESHOLD;
+        return secondsSince(pingedAt > 0 ? pingedAt : startedAt) > staleThresholdInSecond;
     }
 
     private boolean disconnectedRecently() {
-        return disconnectedAt != 0 && secondsSince(disconnectedAt) < STALE_THRESHOLD;
+        return disconnectedAt != 0 && secondsSince(disconnectedAt) < staleThresholdInSecond;
     }
 
     private long getInterval() {
@@ -120,5 +122,10 @@ public class ConnectionMonitor {
 
     private static double clamp(double number, int min, int max) {
         return Math.max(min, Math.min(max, number));
+    }
+
+
+    /*package*/ void setStaleThresholdInSecond(int staleThresholdInSecond) {
+        this.staleThresholdInSecond = staleThresholdInSecond;
     }
 }

--- a/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
+++ b/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
@@ -31,6 +31,8 @@ public class ConnectionMonitor {
     private long stoppedAt = 0; // milliseconds
 
     private int reconnectAttempts = 0;
+    
+    private boolean pingPong = false;
 
     /*package*/ ConnectionMonitor(Connection connection, Connection.Options options) {
         this.connection = connection;
@@ -40,6 +42,7 @@ public class ConnectionMonitor {
         this.reconnectionMaxAttempts = options.reconnectionMaxAttempts;
         this.reconnectionDelay = options.reconnectionDelay;
         this.reconnectionDelayMax = options.reconnectionDelayMax;
+        this.pingPong = options.pingPong;
     }
 
     /*package*/ void recordConnect() {
@@ -54,6 +57,9 @@ public class ConnectionMonitor {
 
     /*package*/ void recordPing() {
         pingedAt = now();
+        if(pingPong) {
+            connection.send(Command.pong().toJson());
+        }
     }
 
     /*package*/ void start() {

--- a/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
+++ b/src/main/java/com/hosopy/actioncable/ConnectionMonitor.java
@@ -113,6 +113,10 @@ public class ConnectionMonitor {
         return (long) clamp(interval, reconnectionDelay, reconnectionDelayMax) * 1000;
     }
 
+    public int getReconnectAttempts() {
+        return reconnectAttempts;
+    }
+
     private static long secondsSince(long time) {
         return (now() - time) / 1000;
     }

--- a/src/main/java/com/hosopy/actioncable/Consumer.java
+++ b/src/main/java/com/hosopy/actioncable/Consumer.java
@@ -123,6 +123,10 @@ public class Consumer {
         return connection.send(command.toJson());
     }
 
+    public void setStaleThresholdInSecond(int staleThresholdInSecond){
+        if(connectionMonitor !=null) connectionMonitor.setStaleThresholdInSecond(staleThresholdInSecond);
+    }
+
     public Connection getConnection() {
         return connection;
     }

--- a/src/main/java/com/hosopy/actioncable/Consumer.java
+++ b/src/main/java/com/hosopy/actioncable/Consumer.java
@@ -127,7 +127,19 @@ public class Consumer {
         return connection;
     }
 
+    public boolean isConnecting() {
+        return this.connection != null && this.connection.isConnecting();
+    }
+
     public boolean isConnected() {
         return this.connection != null && this.connection.isOpen();
+    }
+
+    public boolean isClosing() {
+        return this.connection != null && this.connection.isClosing();
+    }
+
+    public boolean isClosed() {
+        return this.connection == null || this.connection.isClosed();
     }
 }

--- a/src/main/java/com/hosopy/actioncable/Consumer.java
+++ b/src/main/java/com/hosopy/actioncable/Consumer.java
@@ -127,6 +127,10 @@ public class Consumer {
         if(connectionMonitor !=null) connectionMonitor.setStaleThresholdInSecond(staleThresholdInSecond);
     }
 
+    public boolean hasSubscription(String channel) {
+        return subscriptions != null && subscriptions.hasSubscription(channel);
+    }
+
     public Connection getConnection() {
         return connection;
     }

--- a/src/main/java/com/hosopy/actioncable/Consumer.java
+++ b/src/main/java/com/hosopy/actioncable/Consumer.java
@@ -159,4 +159,10 @@ public class Consumer {
     public boolean isClosed() {
         return this.connection == null || this.connection.isClosed();
     }
+
+    public Integer getReconnectAttempts() {
+        if (connectionMonitor != null)
+        return connectionMonitor.getReconnectAttempts();
+        else return null;
+    }
 }

--- a/src/main/java/com/hosopy/actioncable/Consumer.java
+++ b/src/main/java/com/hosopy/actioncable/Consumer.java
@@ -127,8 +127,17 @@ public class Consumer {
         if(connectionMonitor !=null) connectionMonitor.setStaleThresholdInSecond(staleThresholdInSecond);
     }
 
+    @Deprecated
     public boolean hasSubscription(String channel) {
         return subscriptions != null && subscriptions.hasSubscription(channel);
+    }
+
+    public boolean hasChannel(String channel) {
+        return subscriptions != null && subscriptions.hasChannel(channel);
+    }
+
+    public boolean hasSubscriptionFor(String identifier) {
+        return subscriptions != null && subscriptions.hasSubscriptionOf(identifier);
     }
 
     public Connection getConnection() {

--- a/src/main/java/com/hosopy/actioncable/GeneralListener.java
+++ b/src/main/java/com/hosopy/actioncable/GeneralListener.java
@@ -1,0 +1,21 @@
+package com.hosopy.actioncable;
+
+
+/**
+ * GeneralListener provides a number of callbacks  for calling remote procedure calls
+ * on the corresponding Channel instance on the server side.
+ *
+ */
+public interface GeneralListener {
+    public void onMessage(String string);
+    /**
+     * onOpen can be called multi-times
+     * e.g.[on connection establish, on welcome message received]
+     *
+     */
+    public void onOpen();
+    public void onSend(String data);
+    public void onClosing();
+    public void onClosed();
+    public void onFailure(Exception e);
+}

--- a/src/main/java/com/hosopy/actioncable/SubscriptionProxy.java
+++ b/src/main/java/com/hosopy/actioncable/SubscriptionProxy.java
@@ -45,6 +45,10 @@ public class SubscriptionProxy<T extends Subscription> {
         return channel.toIdentifier();
     }
 
+    /*package*/ String getChannelName() {
+        return channel.getName();
+    }
+
     /*package*/ void onConnected(Subscription.ConnectedCallback callback) {
         onConnected = callback;
     }

--- a/src/main/java/com/hosopy/actioncable/Subscriptions.java
+++ b/src/main/java/com/hosopy/actioncable/Subscriptions.java
@@ -136,4 +136,13 @@ public class Subscriptions {
     private boolean sendSubscribeCommand(SubscriptionProxy subscriptionProxy) {
         return consumer.send(Command.subscribe(subscriptionProxy.getIdentifier()));
     }
+
+    /*package*/ boolean hasSubscription(String channelName) {
+        for (SubscriptionProxy subscription : subscriptionProxies.values()) {
+            if (subscription.getChannelName().equals(channelName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/hosopy/actioncable/Subscriptions.java
+++ b/src/main/java/com/hosopy/actioncable/Subscriptions.java
@@ -65,6 +65,19 @@ public class Subscriptions {
     }
 
     /**
+     * Remove subscription from collection.
+     *
+     * @param channelName channel name of an exist subscription to remove
+     */
+    public void remove(String channelName) {
+        for (SubscriptionProxy subscription : subscriptionProxies.values()) {
+            if (subscription.getChannelName().equals(channelName)) {
+                remove(subscription.getProxy());
+            }
+        }
+    }
+
+    /**
      * Remove all subscriptions from collection.
      */
     public void removeAll() {

--- a/src/main/java/com/hosopy/actioncable/Subscriptions.java
+++ b/src/main/java/com/hosopy/actioncable/Subscriptions.java
@@ -150,6 +150,7 @@ public class Subscriptions {
         return consumer.send(Command.subscribe(subscriptionProxy.getIdentifier()));
     }
 
+    @Deprecated(since = "use hasChannel()")
     /*package*/ boolean hasSubscription(String channelName) {
         for (SubscriptionProxy subscription : subscriptionProxies.values()) {
             if (subscription.getChannelName().equals(channelName)) {
@@ -158,4 +159,23 @@ public class Subscriptions {
         }
         return false;
     }
+
+    /*package*/ boolean hasChannel(String channelName) {
+        for (SubscriptionProxy subscription : subscriptionProxies.values()) {
+            if (subscription.getChannelName().equals(channelName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*package*/ boolean hasSubscriptionOf(String identifier) {
+        for (SubscriptionProxy subscriptionProxy : subscriptionProxies.values()) {
+            if (subscriptionProxy.getIdentifier().equals(identifier)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/com/hosopy/actioncable/Subscriptions.java
+++ b/src/main/java/com/hosopy/actioncable/Subscriptions.java
@@ -69,9 +69,22 @@ public class Subscriptions {
      *
      * @param channelName channel name of an exist subscription to remove
      */
+    @Deprecated
     public void remove(String channelName) {
         for (SubscriptionProxy subscription : subscriptionProxies.values()) {
             if (subscription.getChannelName().equals(channelName)) {
+                remove(subscription.getProxy());
+            }
+        }
+    }
+    /**
+     * Remove subscription from collection.
+     *
+     * @param identifier channel name of an exist subscription to remove
+     */
+    public void removeByIdentifier(String identifier) {
+        for (SubscriptionProxy subscription : subscriptionProxies.values()) {
+            if (subscription.getIdentifier().equals(identifier)) {
                 remove(subscription.getProxy());
             }
         }

--- a/src/main/java/com/hosopy/actioncable/WebSocketException.java
+++ b/src/main/java/com/hosopy/actioncable/WebSocketException.java
@@ -1,0 +1,8 @@
+package com.hosopy.actioncable;
+
+public class WebSocketException extends Exception {
+
+    /*package*/ WebSocketException(Throwable t) {
+        super(t);
+    }
+}

--- a/src/main/java/com/hosopy/actioncable/annotation/Exceptions.kt
+++ b/src/main/java/com/hosopy/actioncable/annotation/Exceptions.kt
@@ -1,0 +1,3 @@
+package com.hosopy.actioncable.annotation
+
+class WebSocketException(e: Throwable) : Exception(e)

--- a/src/main/java/com/hosopy/actioncable/annotation/Exceptions.kt
+++ b/src/main/java/com/hosopy/actioncable/annotation/Exceptions.kt
@@ -1,3 +1,0 @@
-package com.hosopy.actioncable.annotation
-
-class WebSocketException(e: Throwable) : Exception(e)


### PR DESCRIPTION
- Close socket in onClosing:
  WebSocket connection should be properly closed when it’s in the "closing" state. This is crucial to avoid leaving hanging connections or resources.
- Pass exception & skip open connection if it is connecting:
  It’s a good practice to ensure that if a connection is already in the process of being established (connecting state), no additional attempts should be made. This can prevent race conditions and multiple attempts to open the same connection.
- Add WebSocketException.java:
  Introducing a custom exception class (WebSocketException) is useful for catching and handling WebSocket-related errors more effectively.
- Add hasSubscription function:
  This function checks whether the current WebSocket connection has a subscription. It can be valuable in preventing the same subscription channels from being added twice.
- Add setStaleThresholdInSecond():
  This method might be used to define a threshold for considering connections as stale. 
- Expose more connection status check functions:
  This improves the ability to track the connection state (e.g., connecting, connected, closed), which helps in handling different scenarios like reconnection or error handling.
- Add IDEAL as initialize status:
  Introducing a status like IDEAL as an initialization status can help signify that the WebSocket is not yet connected and is ready to initiate the connection, which could be important for managing transitions even before the connection starts.
- Add auto ping-pong:
  Automatic ping-pong mechanisms are often used to keep WebSocket connections alive and to detect when a connection is lost. 